### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ achieved with
 
     $ source <(docker-ls autocomplete bash)
 
+or to avoid "carriage return" erros on some scenarios,
+
+    $ source <(docker-ls autocomplete bash | sed 's/\r//')
+
+
 # License
 
 Docker-ls is distributed under the terms of the MIT license.


### PR DESCRIPTION
Solve "carriage return" errors:

# source <(docker-ls autocomplete bash)
bash: $'\r': command not found
bash: /dev/fd/63: line 3: syntax error near unexpected token `$'\r''
'ash: /dev/fd/63: line 3: `__docker-ls_debug()